### PR TITLE
is_admin() should not verify user roles

### DIFF
--- a/framework/actions.php
+++ b/framework/actions.php
@@ -39,7 +39,7 @@ add_action('admin_head', function() use ($config)
 	$elements = '#menu-';
 	$separator = ', #menu-';
 
-	if (is_admin())
+	if (current_user_can('manage_options'))
 	{
 		$elements .= implode(
 			$separator,


### PR DESCRIPTION
is_admin() should not be used as a means to verify whether the current user has permission to view the Dashboard or the administration panel. 

http://codex.wordpress.org/Function_Reference/is_admin
