### PR TITLE
Empty trash more often for optimization of WP

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -37,6 +37,9 @@ define('DB_COLLATE', '');
 define('WP_CONTENT_DIR', dirname( __FILE__ ) . '/wp-content');
 define('WP_CONTENT_URL', 'http://' . $_SERVER['HTTP_HOST'] . '/wp-content');
 
+/** Set the trash to less days to optimize WP */
+define ('EMPTY_TRASH_DAYS', 7); // default 30
+
 /**#@+
  * Authentication Unique Keys and Salts.
  *


### PR DESCRIPTION
Trash can take up a lot of unnecessary room in your website’s database. The bigger the database, the longer it is to retrieve information from it.

`EMPTY_TRASH_DAYS` gets defined at `wp-settings.php`, via `default-constants.php`. So, you have to define it in `wp-config.php`, if you want to override the default.
