### PR TITLE
Use PHP instead of rm in post-create-project-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "scripts": {
         "post-create-project-cmd": [
             "php -r \"copy('.env.example', '.env');\"",
-            "rm README.md LICENSE CHANGELOG.md CONTRIBUTING.md .styleci.yml"
+            "php -r \"array_map('unlink', ['README.md', 'LICENSE', 'CHANGELOG.md', 'CONTRIBUTING.md', '.styleci.yml']);\""
         ]
     },
     "extra":{


### PR DESCRIPTION
Windows doesn't have `rm`, plus it just seems a bit cleaner/neater to keep everything within PHP.

(note: this is untested, but it should work.)