### PR TITLE
Composer installer and ignore error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 composer.lock
 phpunit.xml
+
 vendor
+wp-content
+wordpress
+
 .env
 
 /public/languages
 /public/plugins
 /public/upgrade
 /public/uploads
-/public/wordpress


### PR DESCRIPTION
Since upgrading to the composer installer for Wordplate, the ignore doesn't match the new folders!