### PR TITLE
wp_title(); will be printed in wp_head();

### DIFF
--- a/public/themes/wordplate/header.php
+++ b/public/themes/wordplate/header.php
@@ -6,8 +6,6 @@
   <meta name="viewport" content="width=device-width">
   <meta name="theme-color" content="#464646">
 
-  <title><?php wp_title(); ?></title>
-
   <meta name="author" content="">
   <meta name="description" content="">
 


### PR DESCRIPTION
wp_title() is now printed two times. This fixes this bug.