### PR TITLE
Replace css and js default file names in enqueue functions

### DIFF
--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -29,9 +29,9 @@ add_action('after_setup_theme', function () {
 add_action('wp_enqueue_scripts', function () {
     wp_deregister_script('jquery');
 
-    // wp_enqueue_style('wordplate', elixir('styles/wordplate.css'));
+    // wp_enqueue_style('wordplate', elixir('styles/app.css'));
 
-    // wp_register_script('wordplate', elixir('scripts/wordplate.js'), '', '', true);
+    // wp_register_script('wordplate', elixir('scripts/app.js'), '', '', true);
     // wp_enqueue_script('wordplate');
 });
 


### PR DESCRIPTION
Because the default Wordplate install uses app.css and app.js as file names