### PR TITLE
WP-CLI compatibility

### DIFF
--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -25,7 +25,7 @@ define('DB_CHARSET', env('DB_CHARSET', 'utf8'));
 define('DB_COLLATE', env('DB_COLLATE', ''));
 
 /* Set the home url to the current domain. */
-define('WP_HOME', env('WP_URL', 'http://'.array_get($_SERVER, 'HTTP_HOST'));
+define('WP_HOME', env('WP_URL', 'http://'.array_get($_SERVER, 'HTTP_HOST')));
 
 /* Custom WordPress directory. */
 define('WP_SITEURL', env('WP_SITEURL', WP_HOME.'/'.env('WP_DIR', 'wordpress')));

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -25,7 +25,7 @@ define('DB_CHARSET', env('DB_CHARSET', 'utf8'));
 define('DB_COLLATE', env('DB_COLLATE', ''));
 
 /* Set the home url to the current domain. */
-define('WP_HOME', env('WP_URL', 'http://'.$_SERVER['HTTP_HOST']));
+define('WP_HOME', env('WP_URL', 'http://'.array_get($_SERVER, 'HTTP_HOST'));
 
 /* Custom WordPress directory. */
 define('WP_SITEURL', env('WP_SITEURL', WP_HOME.'/'.env('WP_DIR', 'wordpress')));

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,1 @@
+path: public/wordpress


### PR DESCRIPTION
Without this configuration, WP-CLI does not know where WordPress core is installed and will error with a message like this:

```
Error: This does not seem to be a WordPress install.
Pass --path=`path/to/wordpress` or run `wp core download`.
```