### PR TITLE
Remove JPEG compression by Wordpress.

### DIFF
--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -72,6 +72,13 @@ add_filter('wp_title', function () {
 });
 
 /*
+ * Remove JPG compression.
+ */
+add_filter('jpeg_quality', function () {
+    return 100;
+}, 10, 2);
+
+/*
  * Set custom excerpt more.
  */
 add_filter('excerpt_more', function () {


### PR DESCRIPTION
If a user should need compression they should install a plugin or some service to handle the image compression so the file doesn't loose quality.