### PR TITLE
gitignore ".idea/" by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 npm-debug.log
 Vagrantfile
 vendor
+.idea


### PR DESCRIPTION
Ignore Jetbrains generated project specific settings.
This will prevent the application being "IDE specific".