### PR TITLE
Include node_modules in includePaths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,11 @@ elixir.config.js.folder = 'scripts';
 elixir.config.js.outputFolder = 'scripts';
 
 elixir(function (mix) {
-  mix.sass('app.scss');
+  mix.sass('app.scss', null, null, {
+    includePaths: [
+      './node_modules'
+    ]
+  });
 
   mix.browserify('app.js');
 


### PR DESCRIPTION
This enables users to include libraries from their node_modules directly in their scss-files. For example:

```
@import 'sanitize.css/lib/sanitize.scss';
```

Instead of:

```
@import '../../../node_modules/sanitize.css/lib/sanitize.scss';
```