### PR TITLE
Add wordpress' comments to default mod_rewrite block

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,8 +1,11 @@
+# BEGIN WordPress
 <IfModule mod_rewrite.c>
-	RewriteEngine On
-	RewriteBase /
-	RewriteRule ^index\.php$ - [L]
-	RewriteCond %{REQUEST_FILENAME} !-f
-	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteRule . /index.php [L]
+    RewriteEngine On
+    RewriteBase /
+    RewriteRule ^index\.php$ - [L]
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule . /index.php [L]
 </IfModule>
+
+# END WordPress


### PR DESCRIPTION
Issue: when Wordpress installs it adds this mod_rewrite block again since isn't tagged with "BEGIN WordPress"