### PR TITLE
Include node_modules in sass

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -17,5 +17,7 @@ const public = 'public/themes/wordplate/assets';
 mix.setPublicPath(public);
 
 mix.js(`${resources}/scripts/app.js`, `${public}/scripts`)
-   .sass(`${resources}/styles/app.scss`, `${public}/styles`)
+   .sass(`${resources}/styles/app.scss`, `${public}/styles`, {
+      includePaths: ['node_modules'],
+   })
    .version();


### PR DESCRIPTION
Include node_modules so we easily can include packages in node_modules directly in our sass. For example:

```
@import 'sanitize.scss/sanitize';
```