### PR TITLE
Set resourceRoot

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -16,6 +16,7 @@ const themePath = 'public/themes/wordplate';
 const assetsPath = `${themePath}/assets`;
 
 mix.setPublicPath(assetsPath);
+mix.setResourceRoot('../');
 
 mix.browserSync({
     proxy: 'wordplate.dev',


### PR DESCRIPTION
set `mix.setResourceRoot('../');` to make css find fonts and images. Otherwise the css is looking in the root.