### PR TITLE
app.scss can't be empty.

### DIFF
--- a/resources/assets/styles/app.scss
+++ b/resources/assets/styles/app.scss
@@ -1,0 +1,1 @@
+/* WordPlate */


### PR DESCRIPTION
In order to compile the app.scss the file can't be empty. Fixes #172