### PR TITLE
Removed deprecated function for wp_title

### DIFF
--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -43,28 +43,6 @@ add_action('wp_enqueue_scripts', function () {
     // wp_enqueue_script('wordplate');
 });
 
-// Set custom title.
-add_filter('wp_title', function () {
-    global $post;
-
-    $name = get_bloginfo('name');
-    $description = get_bloginfo('description');
-
-    if (is_front_page() || is_home()) {
-        if ($description) {
-            return sprintf('%s - %s', $name, $description);
-        }
-
-        return $name;
-    }
-
-    if (is_category()) {
-        return sprintf('%s - %s', trim(single_cat_title('', false)), $name);
-    }
-
-    return sprintf('%s - %s', trim($post->post_title), $name);
-});
-
 // Remove JPEG compression.
 add_filter('jpeg_quality', function () {
     return 100;


### PR DESCRIPTION
wp_title is deprecated, see https://make.wordpress.org/core/2015/10/20/document-title-in-4-4/

We will let the user choose their own way and for reference they can use the following functions:

[pre_get_document_title ](https://developer.wordpress.org/reference/hooks/pre_get_document_title/)– short-circuits wp_get_document_title() if it returns anything other than an empty value.
[document_title_separator](https://developer.wordpress.org/reference/hooks/document_title_separator/) – filters the separator between title parts.
[document_title_parts](https://developer.wordpress.org/reference/hooks/document_title_parts/) – filters the parts that make up the document title, passed in an associative array.