### PR TITLE
Simplify Laravel Mix Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,6 @@ If you want to enable standard plugins to be required just like [must-use](https
 
 WordPlate has integrated [Laravel Mix](https://laravel.com/docs/5.4/mix) out of the box. It provides a clean, fluent API for defining basic Webpack build steps for your WordPlate application.
 
-#### Tasks
-
-WordPlate ships with three [npm scripts](https://docs.npmjs.com/misc/scripts) in the `package.json` file for Laravel Mix.
-
-- `dev` - Run all Laravel Mix tasks.
-- `production` - Run all Laravel Mix tasks and minify output.
-- `watch` - Run all Laravel Mix tasks, start Browsersync and watch for file changes.
-
 [Read more about how to install and use Laravel Mix in the official documentation.](https://laravel.com/docs/5.4/mix)
 
 ## Mail

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
         "production": "node node_modules/cross-env/dist/bin/cross-env.js NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
-        "laravel-mix": "^0.8.1"
+        "laravel-mix": "^0.11.4"
     }
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -11,29 +11,10 @@ const { mix } = require('laravel-mix');
  |
  */
 
-const resources = 'resources/assets';
-const themePath = 'public/themes/wordplate';
-const assetsPath = `${themePath}/assets`;
+const theme = 'wordplate';
 
-mix.setPublicPath(assetsPath);
-mix.setResourceRoot('../');
+mix.setPublicPath(`public/themes/${theme}/assets`);
 
-mix.browserSync({
-    proxy: 'wordplate.dev',
-    files: [
-        `${themePath}/**/*.php`,
-        `${assetsPath}/**/*.js`,
-        `${assetsPath}/**/*.css`
-    ]
-});
-
-mix.js(`${resources}/scripts/app.js`, `${assetsPath}/scripts`);
-
-mix.sass(`${resources}/styles/app.scss`, `${assetsPath}/styles`, {
-    includePaths: ['node_modules']
-});
-
-// Hash and version files in production.
-if (mix.config.inProduction) {
-    mix.version();
-}
+mix.js('resources/assets/scripts/app.js', 'scripts')
+  .sass('resources/assets/styles/app.scss', 'styles')
+  .version();

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -16,5 +16,4 @@ const theme = 'wordplate';
 mix.setPublicPath(`public/themes/${theme}/assets`);
 
 mix.js('resources/assets/scripts/app.js', 'scripts')
-  .sass('resources/assets/styles/app.scss', 'styles')
-  .version();
+  .sass('resources/assets/styles/app.scss', 'styles');


### PR DESCRIPTION
The idea is to simplify the Laravel Mix configuration to make it easier to understand for newcomers. Right now new users are having problem with Browsersync if they haven't setup the proxy. We're also seeing issue with public path on Windows. This pull request will fix this request.