### PR TITLE
Don't disable screen-options by default

### DIFF
--- a/public/themes/wordplate/includes/plugins/plate.php
+++ b/public/themes/wordplate/includes/plugins/plate.php
@@ -65,7 +65,7 @@ add_theme_support('plate-disable-toolbar', [
 ]);
 
 // Disable dashboard tabs.
-add_theme_support('plate-disable-tabs', ['help', 'screen-options']);
+add_theme_support('plate-disable-tabs', ['help']);
 
 // Set custom permalink structure.
 add_theme_support('plate-permalink', '/%postname%/');


### PR DESCRIPTION
This pull request displays the `screen-options` tab by default. I often find myself enabling the tab.