### PR TITLE
Added manifest.json file

### DIFF
--- a/public/themes/wordplate/header.php
+++ b/public/themes/wordplate/header.php
@@ -3,7 +3,17 @@
 <head>
   <meta charset="<?php bloginfo('charset'); ?>">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="<?php bloginfo('name'); ?>">
+  <meta name="application-name" content="<?php bloginfo('name'); ?>">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="theme-color" content="#6d9aea">
+
+  <link rel="apple-touch-icon" href="<?php echo asset('assets/images/icon-192.png'); ?>">
+  <link rel="icon" sizes="192x192" href="<?php echo asset('assets/images/favicon.png'); ?>">
+  <link rel="shortcut icon" href="<?php echo asset('assets/images/favicon.png'); ?>">
+  <link rel="manifest" href="<?php echo asset('manifest.json'); ?>">
 
   <?php wp_head(); ?>
 </head>

--- a/public/themes/wordplate/manifest.json
+++ b/public/themes/wordplate/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "WordPlate",
+  "short_name": "WordPlate",
+  "icons": [{
+        "src": "/themes/wordplate/assets/images/icon-192.png",
+        "sizes": "192x192",
+        "type": "image/png"
+      }, {
+        "src": "/themes/wordplate/assets/images/icon-512.png",
+        "sizes": "512x512",
+        "type": "image/png"
+      }],
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#6d9aea"
+}


### PR DESCRIPTION
From day one we've wanted WordPlate to adapt to new techniques. This pull request adds basic support for PWA such as a [`manifest.json`](https://developers.google.com/web/fundamentals/web-app-manifest/) file. It also adds `<meta>` fields for favicon and `apple-touch-icon` in order to be able to install an application on iOS devices. These fields are not provided by SEO plugins. Personally, I'm adding these fields to all WordPlate application I build.


There are some questions to answer: 
1. Will this conflict with the built-in favicon generator?
2. Will these fields and file be confusing for new-comers or are we pushing them in the right direction?

@wordplate/developers what is your opinion of this pull request?