### PR TITLE
Update laravel-mix to version 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "cross-env": "^5.2.0",
         "dotenv": "^6.0.0",
-        "laravel-mix": "^2.1.11"
+        "laravel-mix": "^4.0.0"
     },
     "browserslist": [
         ">0.25%",


### PR DESCRIPTION
Laravel Mix 4.0 is just around the corner featuring Babel 7 and Webpack 4. Once it is released we'll merge this pull request. This will be part of the next major release of WordPlate.