### PR TITLE
Add framework 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "wordplate/framework": "^7.1",
+        "wordplate/framework": "^8.0",
         "wordplate/plate": "^4.1"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.2",
         "wordplate/framework": "^8.0",
-        "wordplate/plate": "^4.1"
+        "wordplate/plate": "^5.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "wordplate/framework": "^7.1",
         "wordplate/plate": "^4.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.2",
         "wordplate/framework": "^8.0",
-        "wordplate/plate": "^5.0"
+        "wordplate/plate": "^6.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "cross-env": "^6.0.0",
-        "dotenv": "^8.0.0",
+        "dotenv": "^8.2.0",
         "laravel-mix": "^5.0.0"
     },
     "browserslist": [

--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // Register plugin helpers.
-require template_path('includes/plugins/plate.php');
+require get_theme_file_path('includes/plugins/plate.php');
 
 // Set theme defaults.
 add_action('after_setup_theme', function () {

--- a/public/themes/wordplate/header.php
+++ b/public/themes/wordplate/header.php
@@ -11,6 +11,6 @@
 
     <header>
         <nav role="navigation">
-            <?php wp_nav_menu(['theme_location' => 'primary-menu']); ?>
+            <?php wp_nav_menu(['theme_location' => 'navigation']); ?>
         </nav>
     </header>

--- a/public/themes/wordplate/header.php
+++ b/public/themes/wordplate/header.php
@@ -8,7 +8,6 @@
   <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
-
     <header>
         <nav role="navigation">
             <?php wp_nav_menu(['theme_location' => 'navigation']); ?>

--- a/public/themes/wordplate/includes/plugins/plate.php
+++ b/public/themes/wordplate/includes/plugins/plate.php
@@ -71,7 +71,7 @@ add_theme_support('plate-disable-tabs', ['help']);
 add_theme_support('plate-permalink', '/%postname%/');
 
 // Set custom login logo.
-add_theme_support('plate-login-logo', asset('assets/images/logo.png'));
+add_theme_support('plate-login-logo', get_theme_file_uri('assets/images/logo.png'));
 
 // Set custom footer text.
 add_theme_support('plate-footer-text', 'Thank you for creating with <a href="https://wordplate.github.io/">WordPlate</a>.');

--- a/public/themes/wordplate/includes/plugins/plate.php
+++ b/public/themes/wordplate/includes/plugins/plate.php
@@ -21,23 +21,6 @@ add_theme_support('plate-disable-menu', [
     'upload.php', // media
 ]);
 
-// Disable meta boxes in editor.
-add_theme_support('plate-disable-editor', [
-    'commentsdiv',
-    'commentstatusdiv',
-    'linkadvanceddiv',
-    'linktargetdiv',
-    'linkxfndiv',
-    'postcustom',
-    'postexcerpt',
-    'revisionsdiv',
-    'slugdiv',
-    'sqpt-meta-tags',
-    'trackbacksdiv',
-    //'categorydiv',
-    //'tagsdiv-post_tag',
-]);
-
 // Disable dashboard widgets.
 add_theme_support('plate-disable-dashboard', [
     'dashboard_activity',
@@ -63,9 +46,6 @@ add_theme_support('plate-disable-toolbar', [
     'updates',
     'search',
 ]);
-
-// Disable dashboard tabs.
-add_theme_support('plate-disable-tabs', ['help']);
 
 // Set custom permalink structure.
 add_theme_support('plate-permalink', '/%postname%/');

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -20,5 +20,3 @@ mix.setPublicPath(`public/themes/${theme}/assets`);
 
 mix.js('resources/scripts/app.js', 'scripts');
 mix.sass('resources/styles/app.scss', 'styles');
-
-mix.version();


### PR DESCRIPTION
This pull request adds support for the upcoming version of `wordplate/framework`:

- https://github.com/wordplate/framework/pull/80
- https://github.com/wordplate/framework/pull/81
- https://github.com/wordplate/framework/pull/82
- https://github.com/wordplate/framework/pull/83
- https://github.com/wordplate/framework/pull/84
- https://github.com/wordplate/framework/pull/85
- https://github.com/wordplate/framework/pull/88
- https://github.com/wordplate/framework/pull/89
- https://github.com/wordplate/framework/pull/91

WordPlate 8.0 is planned to be released along WordPress version 5.3.