### PR TITLE
Remove enqueuing and registering assets

### DIFF
--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -32,16 +32,6 @@ add_action('after_setup_theme', function () {
     ]);
 });
 
-// Enqueue and register scripts the right way.
-add_action('wp_enqueue_scripts', function () {
-    wp_deregister_script('jquery');
-
-    // wp_enqueue_style('wordplate', mix('styles/app.css'));
-
-    // wp_register_script('wordplate', mix('scripts/app.js'), '', '', true);
-    // wp_enqueue_script('wordplate');
-});
-
 // Remove JPEG compression.
 add_filter('jpeg_quality', function () {
     return 100;


### PR DESCRIPTION
This pull request removes enqueuing and registering styles and scripts "the right way". In a world of bundlers this is no longer always necessary. We shouldn't tell users of WordPlate this is the right way to import your CSS and JavaScript assets.

This pull requests:

- Stops deregistering jQuery (doesn't seem to do anything in the front-end anyway)
- Removes the CSS and JavaScript enqueuing and registering

Google recently put together a theme in collaboration with WordPress. They didn't use the enqueuing system for neither [CSS](https://github.com/GoogleChromeLabs/ProgressiveWordPress/blob/84feb91b456ad2d9d7b49cd54bac83d7b9e3c03a/src/theme/header.php#L39-L46) or [JavaScript](https://github.com/GoogleChromeLabs/ProgressiveWordPress/blob/84feb91b456ad2d9d7b49cd54bac83d7b9e3c03a/src/theme/footer.php#L46-L50).