### PR TITLE
Added roots/bedrock-autoloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ npm run build
 ## Upgrade Guide
 
 <details>
+<summary><strong>Upgrading from 8 to 9</strong></summary>
+
+1. Bump the version number in the `composer.json` file to `^9.0`.
+
+1. Copy the `public/mu-plugins/mu-plugins.php` file into your project.
+
+1. Run `composer update` in the root of your project and your app should be up and running!
+</details>
+<details>
 <summary><strong>Upgrading from 7 to 8</strong></summary>
 
 1. WordPlate now requires PHP 7.2 or later.
@@ -407,7 +416,8 @@ If you or a company you work for use WordPlate, please consider buying a copy of
 WordPlate wouldn't be possible without these amazing open-source projects.
 
 - [`composer/installers`](https://github.com/composer/installers)
-- [`johnpbloch/wordpress`](https://github.com/johnpbloch/wordpress)
+- [`johnpbloch/wordpress-core`](https://github.com/johnpbloch/wordpress-core)
+- [`johnpbloch/wordpress-core-installer`](https://github.com/johnpbloch/wordpress-core-installer)
 - [`laravel-mix`](https://github.com/JeffreyWay/laravel-mix)
 - [`roots/bedrock-autoloader`](https://github.com/roots/bedrock-autoloader)
 - [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt)

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "roots/bedrock-autoloader": "^1.0",
         "wordplate/framework": "^8.1"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
+        "roots/bedrock-autoloader": "^1.0",
         "wordplate/framework": "^8.1"
     },
     "config": {

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,5 +1,6 @@
 languages
-mu-plugins
+mu-plugins/*
+!mu-plugins/mu-plugins.php
 plugins/*
 !plugins/index.php
 upgrade

--- a/public/mu-plugins/mu-plugins.php
+++ b/public/mu-plugins/mu-plugins.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Plugin Name: Must Use Plugins
+ * Plugin URI: https://github.com/roots/bedrock-autoloader
+ * Description: Must-use plugins (a.k.a. mu-plugins) are plugins installed in a special directory inside the content folder and which are automatically enabled on all sites in the installation.
+ * Version: 1.0.0
+ * Author: Roots
+ * Author URI: https://roots.io/
+ * License: MIT
+ */
+
+if (is_blog_installed()) {
+    new Roots\Bedrock\Autoloader();
+}


### PR DESCRIPTION
This pull request moves the mu-plugin loader out from the framework into the application. This will allow us to use @roots `roots/bedrock-autoloader` package. 

There are some benefits: 

- We work together with @roots to provide the best mu-plugins experience possible.
- We move out WordPress hooks from `wordplate/framework`.

Please see https://github.com/roots/bedrock/issues/299 and https://github.com/wordplate/framework/pull/98 for more information.