### PR TITLE
Added documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,13 +7,7 @@ DB_NAME=wordplate
 DB_USER=wordplate
 DB_PASSWORD=secret
 
-MAIL_HOST=smtp.mailtrap.io
-MAIL_PORT=2525
-MAIL_USERNAME=null
-MAIL_PASSWORD=null
-MAIL_ENCRYPTION=null
-
-# Generate your keys here: https://wordplate.github.io/salt/
+# https://wordplate.github.io/salt/
 AUTH_KEY=
 SECURE_AUTH_KEY=
 LOGGED_IN_KEY=

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you're running an older version of WordPlate and want to upgrade, please see 
 
 <details>
 <summary><strong>Can I change the name of the public directory?</strong></summary>
-<br>
+
 If you want to rename the `public` directory you'll need to add the following line to the `wp-config.php` file:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ composer create-project wordplate/wordplate
 
 WordPlate is simply a wrapper around WordPress to make developers life easier. It is just like building any other WordPress website with [themes](https://developer.wordpress.org/themes) and [plugins](https://developer.wordpress.org/plugins). Just with sprinkles on top.
 
-#### WordPress + Composer = &#x2665;
+#### WordPress + Composer = ♥️
 
 WordPress is installed using Composer which allows WordPress to be updated by running `composer update`.
 
@@ -98,6 +98,21 @@ The next thing you should do after installing WordPlate is adding salt keys to y
 Typically, these strings should be 64 characters long. The keys can be set in the `.env` environment file. If you have not copied the `.env.example` file to a new file named `.env`, you should do that now. **If the salt keys isn't set, your user sessions and other encrypted data will not be secure.**
 
 If you're lazy like us, [visit our salt key generator](https://wordplate.github.io/salt) and copy the randomly generated keys to your `.env` file.
+
+## Laravel Mix
+
+To get started with Laravel Mix, [please visit their documentation](https://laravel-mix.com/docs/5.0/basic-example).
+> [Laravel Mix](https://laravel-mix.com/docs/5.0/basic-example) is a clean layer on top of Webpack to make the 80% use case laughably simple to execute. Most would agree that, though incredibly powerful, Webpack ships with a steep learning curve. But what if you didn't have to worry about that?
+
+By default there are two npm scripts available:
+
+```sh
+// Run all mix tasks...
+npm run dev
+
+// Run all mix tasks and minify output...
+npm run build
+```
 
 ## Upgrade Guide
 
@@ -251,7 +266,7 @@ final class LocalValetDriver extends BasicValetDriver
 ```
 </details>
 
-## Support &#x2665;
+## Support ♥️
 
 If you or a company you work for use WordPlate, please consider buying a copy of the [Administration UI](https://vinkla.dev/administration-ui) plugin. This will not only make your clients happy, it will also help use maintain and push WordPlate forward.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ WordPlate is simply a wrapper around WordPress to make developers life easier. I
 - [Features](#features)
 - [Installation](#installation)
 - [Configuration](#configuration)
+- [Plugins](#plugins)
+- [Laravel Mix](#laravel-mix)
 - [Upgrade Guide](#upgrade-guide)
 - [FAQ](#faq)
 - [Support](#support)
@@ -59,7 +61,7 @@ WordPlate utilizes [Composer](https://getcomposer.org/) to manage its dependenci
 Install WordPlate by issuing the Composer `create-project` command in your terminal:
 
 ```sh
-$ composer create-project --prefer-dist wordplate/wordplate blog
+composer create-project --prefer-dist wordplate/wordplate blog
 ```
 
 Update the database credentials in the `.env` file:
@@ -73,7 +75,7 @@ DB_PASSWORD=password
 Serve your application using the [built-in web server in PHP](https://www.php.net/manual/en/features.commandline.webserver.php) (or your server of choice) from the `public` directory:
 
 ```sh
-$ php -S localhost:8000 -t public/
+php -S localhost:8000 -t public/
 ```
 
 Visit your application in the browser:
@@ -108,11 +110,59 @@ Read more about environment variables in Laravel's documentation:
 - [Environment Variable Types](https://laravel.com/docs/7.x/configuration#environment-variable-types)
 - [Retrieving Environment Configuration](https://laravel.com/docs/7.x/configuration#retrieving-environment-configuration)
 
+## Plugins
+
+### WordPress Packagist
+
+We've integrated [WordPress Packagist](https://wpackagist.org) which makes it possible to install plugins with Composer. WordPress Packagist mirrors the WordPress plugin and theme directories as a Composer repository.
+
+Install the desired plugins using `wpackagist-plugin` as the vendor name. Packages are installed in the `public/plugins` directory.
+
+```bash
+composer require wpackagist-plugin/hide-updates
+```
+
+This is an example of how your `composer.json` file might look like:
+
+```json
+"require": {
+    "wordplate/framework": "^7.1",
+    "wpackagist-plugin/hide-updates": "^1.0"
+},
+```
+
+[Please visit WordPress Packagist for more information and examples.](https://wpackagist.org)
+
+### Must Use Plugins
+
+[Must-use plugins](https://wordpress.org/support/article/must-use-plugins/) (a.k.a. mu-plugins) are plugins installed in a special directory inside the content folder and which are automatically enabled on all sites in the installation.
+
+To install plugins into into the `mu-plugins` directory, add the plugin name to the `installer-paths` in your `composer.json` file:
+
+```json
+"installer-paths": {
+    "public/mu-plugins/{$name}": [
+        "type:wordpress-muplugin",
+        "wpackagist-plugin/hide-updates",
+    ]
+}
+```
+
+Install the plugin using `wpackagist-plugin` as the vendor name.
+
+```sh
+composer require wpackagist-plugin/hide-updates
+```
+
+The plugin should now be installed in the `public/mu-plugins` directory.
+
+[Read more about the must-use plugin autoloader in the documentation.](https://roots.io/docs/bedrock/master/mu-plugin-autoloader/)
+
 ## Laravel Mix
 
 [Laravel Mix](https://laravel-mix.com/docs/5.0/basic-example) is a clean layer on top of Webpack to make the 80% use case laughably simple to execute. Most would agree that, though incredibly powerful, Webpack ships with a steep learning curve. But what if you didn't have to worry about that?
 
-To get started with Laravel Mix, [please visit the documentation](https://laravel-mix.com/docs/5.0/basic-example).
+[To get started with Laravel Mix, please visit the documentation.](https://laravel-mix.com/docs/5.0/basic-example)
 
 ```sh
 // Run all mix tasks...
@@ -136,19 +186,19 @@ npm run build
 1. Laravel's helper functions is now optional in WordPlate. If you want to use the functions, install the [`laravel/helpers`](https://github.com/laravel/helpers#readme) package, with Composer, in the root of your project:
 
    ```sh
-   $ composer require laravel/helpers
+   composer require laravel/helpers
    ```
 
 1. Laravel's collections are now optional in WordPlate. If you want to use collections, install the [`tightenco/collect`](https://github.com/tightenco/collect#readme) package, with Composer, in the root of your project:
 
    ```sh
-   $ composer require tightenco/collect
+   composer require tightenco/collect
    ```
 
 1. The `mix` helper function is now optional in WordPlate. If you want to use the function, install the [`ibox/mix-function`](https://github.com/juanem1/mix-function#readme) package, with Composer, in the root of your project:
 
    ```sh
-   $ composer require ibox/mix-function
+   composer require ibox/mix-function
    ```
 
 1. Replace any usage of `asset`, `stylesheet_url` and `template_url` functions with WordPress's [`get_theme_file_uri`](https://developer.wordpress.org/reference/functions/get_theme_file_uri/) function.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ composer create-project wordplate/wordplate
 
 WordPlate is simply a wrapper around WordPress to make developers life easier. It is just like building any other WordPress website with [themes](https://developer.wordpress.org/themes) and [plugins](https://developer.wordpress.org/plugins). Just with sprinkles on top.
 
-#### WordPress + Composer = ♥️
+#### WordPress + Composer = &#x2665;
 
 WordPress is installed using Composer which allows WordPress to be updated by running `composer update`.
 
@@ -251,7 +251,7 @@ final class LocalValetDriver extends BasicValetDriver
 ```
 </details>
 
-## Support ♥️
+## Support &#x2665;
 
 If you or a company you work for use WordPlate, please consider buying a copy of the [Administration UI](https://vinkla.dev/administration-ui) plugin. This will not only make your clients happy, it will also help use maintain and push WordPlate forward.
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ If you're lazy like us, [visit our salt key generator](https://wordplate.github.
 
 ## Laravel Mix
 
-To get started with Laravel Mix, [please visit their documentation](https://laravel-mix.com/docs/5.0/basic-example).
-> [Laravel Mix](https://laravel-mix.com/docs/5.0/basic-example) is a clean layer on top of Webpack to make the 80% use case laughably simple to execute. Most would agree that, though incredibly powerful, Webpack ships with a steep learning curve. But what if you didn't have to worry about that?
+[Laravel Mix](https://laravel-mix.com/docs/5.0/basic-example) is a clean layer on top of Webpack to make the 80% use case laughably simple to execute. Most would agree that, though incredibly powerful, Webpack ships with a steep learning curve. But what if you didn't have to worry about that?
+
+To get started with Laravel Mix, [please visit the documentation](https://laravel-mix.com/docs/5.0/basic-example).
 
 By default there are two npm scripts available:
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ WordPlate is simply a wrapper around WordPress to make developers life easier. I
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Plugins](#plugins)
+- [Integrations](#integrations)
 - [Laravel Mix](#laravel-mix)
 - [Upgrade Guide](#upgrade-guide)
 - [FAQ](#faq)
 - [Support](#support)
+- [Acknowledgements](#acknowledgements)
 - [Contributing](#contributing)
 
 ## Features
@@ -126,7 +128,7 @@ This is an example of how your `composer.json` file might look like:
 
 ```json
 "require": {
-    "wordplate/framework": "^7.1",
+    "wordplate/framework": "^9.0",
     "wpackagist-plugin/hide-updates": "^1.0"
 },
 ```
@@ -157,6 +159,52 @@ composer require wpackagist-plugin/hide-updates
 The plugin should now be installed in the `public/mu-plugins` directory.
 
 [Read more about the must-use plugin autoloader in the documentation.](https://roots.io/docs/bedrock/master/mu-plugin-autoloader/)
+
+## Integrations
+
+- [**Administration UI**](https://vinkla.dev/administration-ui)
+
+  The plugin lets you take control over the WordPress administration dashboard by turning off features you don't use. 
+
+- [**Blade**](https://github.com/fiskhandlarn/blade)
+
+  The plugin integrates [Blade](https://laravel.com/docs/7.x/blade) templating system in WordPress.
+
+- [**Clean Image Filenames**](https://wordpress.org/plugins/clean-image-filenames/)
+
+  The plugin removes special characters from filenames.
+
+- [**Extended ACF**](https://github.com/wordplate/extended-acf)
+
+  The package provides an object oriented API to register fields, groups and layouts with Advanced Custom Fields.
+
+- [**Extended CPTs**](https://github.com/johnbillion/extended-cpts)
+
+  The package provides extended functionality to WordPress custom post types and taxonomies.
+
+- [**Disable Embeds**](https://wordpress.org/plugins/disable-embeds/)
+
+  The plugin prevents others from embedding your site.
+
+- [**Disable Emojis**](https://wordpress.org/plugins/disable-emojis/)
+
+  The plugin disables the new WordPress emoji functionality.
+
+- [**Email Log**](https://wordpress.org/plugins/email-log/)
+
+  The plugin that allows you to log and view all emails sent from WordPress.
+
+- [**Hide Updates**](https://wordpress.org/plugins/hide-updates/)
+
+  The plugin hides update notices for updates in WordPress.
+
+- [**WP Languages**](https://github.com/wp-languages/wp-languages.github.io)
+
+  The Composer repository for WordPress translation files.
+
+- [**WP Migrate DB**](https://wordpress.org/plugins/wp-migrate-db/)
+
+  The plugin help you export your database as a MySQL data dump.
 
 ## Laravel Mix
 
@@ -346,9 +394,23 @@ final class LocalValetDriver extends BasicValetDriver
 ```
 </details>
 
-## Support ♥️
+## Support
 
 If you or a company you work for use WordPlate, please consider buying a copy of the [Administration UI](https://vinkla.dev/administration-ui) plugin. This will not only make your clients happy, it will also help us maintain and push WordPlate forward.
+
+## Acknowledgements
+
+WordPlate wouldn't be possible without these amazing open-source projects.
+
+- [`composer/installers`](https://github.com/composer/installers)
+- [`johnpbloch/wordpress`](https://github.com/johnpbloch/wordpress)
+- [`laravel-mix`](https://github.com/JeffreyWay/laravel-mix)
+- [`roots/bedrock-autoloader`](https://github.com/roots/bedrock-autoloader)
+- [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt)
+- [`symfony/dotenv`](https://github.com/symfony/dotenv)
+- [`symfony/http-foundation`](https://github.com/symfony/http-foundation)
+- [`symfony/routing`](https://github.com/symfony/var-dumper)
+- [`symfony/var-dumper`](https://github.com/symfony/routing)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ $ composer create-project wordplate/wordplate
   - [Salt Keys](#salt-keys)
 - [Upgrade Guide](#upgrade-guide)
 - [FAQ](#faq)
+- [Support](#support)
+- [Contributing](#contributing)
 
 ## Installation
 
@@ -31,11 +33,13 @@ WordPlate utilizes [Composer](https://getcomposer.org/) to manage its dependenci
     $ composer create-project --prefer-dist wordplate/wordplate blog
     ```
 
-1. Add your database credentials to the `.env` file.
+1. Update the database credentials in the `.env` file:
 
-    - `DB_NAME`
-    - `DB_USER`
-    - `DB_PASSWORD`
+    ```
+    DB_NAME=database
+    DB_USER=username
+    DB_PASSWORD=password
+    ```
 
 1. Serve your application using the [built-in web server in PHP](https://www.php.net/manual/en/features.commandline.webserver.php) (or your server of choice) from the `public` directory:
 
@@ -45,8 +49,8 @@ WordPlate utilizes [Composer](https://getcomposer.org/) to manage its dependenci
 
 1. Visit your application in the browser:
 
-    - [`http://localhost:8000/`](http://localhost:8000/) - The WordPress application.
-    - [`http://localhost:8000/wordpress/wp-admin`](http://localhost:8000/wordpress/wp-admin) - The WordPress administration dashboard.
+    - [`http://localhost:8000/`](http://localhost:8000/) - Your website.
+    - [`http://localhost:8000/wordpress/wp-admin`](http://localhost:8000/wordpress/wp-admin) - The administration dashboard.
 
 ## Configuration
 
@@ -152,6 +156,71 @@ $application->setPublicPath(realpath(__DIR__));
 
 Please note that you also have to update your `composer.json` file with your new `public` directory path before you can run `composer update` again.
 </details>
+<details>
+<summary><strong>Can I use WordPlate with Laravel Valet?</strong></summary>
+
+If you're using [Laravel Valet](https://laravel.com/docs/7.x/valet) together with WordPlate, you may use our local valet driver. Create a file named `LocalValetDriver.php` in the root of your project and copy and paste the class below:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+final class LocalValetDriver extends BasicValetDriver
+{
+    public function serves(string $sitePath): bool
+    {
+        return is_dir($sitePath . '/vendor/wordplate/framework');
+    }
+
+    /**
+     * @return false|string
+     */
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    {
+        $staticFilePath = $sitePath . '/public' . $uri;
+
+        if ($this->isActualFile($staticFilePath)) {
+            return $staticFilePath;
+        }
+
+        return false;
+    }
+
+    public function frontControllerPath(string $sitePath, string $siteName, string $uri): string
+    {
+        $_SERVER['PHP_SELF'] = $uri;
+        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+
+        if (strpos($uri, '/wordpress/') === 0) {
+            if (is_dir($sitePath . '/public' . $uri)) {
+                $uri = $this->forceTrailingSlash($uri);
+
+                return $sitePath . '/public' . $uri . '/index.php';
+            }
+
+            return $sitePath . '/public' . $uri;
+        }
+
+        return $sitePath . '/public/index.php';
+    }
+
+    private function forceTrailingSlash(string $uri): string
+    {
+        if (substr($uri, -1 * strlen('/wordpress/wp-admin')) == '/wordpress/wp-admin') {
+            header('Location: ' . $uri . '/');
+            die;
+        }
+
+        return $uri;
+    }
+}
+```
+</details>
+
+## Support ♥️
+
+If you or a company you work for use WordPlate, please consider buying a copy of the [Administration UI](https://vinkla.dev/administration-ui) plugin. This will not only make your clients happy, it will also help use maintain and push WordPlate forward.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![WordPlate](https://cloud.githubusercontent.com/assets/499192/24309675/09eec350-10cd-11e7-98f3-094003bc8e15.png)](https://wordplate.github.io)
 
-WordPlate is a modern WordPress stack which simplifies WordPress development.
+A modern WordPress stack to make PHP developers happier.
 
 ```sh
 $ composer create-project wordplate/wordplate

--- a/README.md
+++ b/README.md
@@ -1,26 +1,6 @@
 # WordPlate
 
-[![WordPlate](https://cloud.githubusercontent.com/assets/499192/24309675/09eec350-10cd-11e7-98f3-094003bc8e15.png)](https://wordplate.github.io)
-
-A modern WordPress stack to make PHP developers happier.
-
-```sh
-$ composer create-project wordplate/wordplate
-```
-
-[![Build Status](https://badgen.net/github/checks/wordplate/framework?label=build&icon=github)](https://github.com/wordplate/framework/actions)
-[![Monthly Downloads](https://badgen.net/packagist/dm/wordplate/framework)](https://packagist.org/packages/wordplate/framework/stats)
-[![Latest Version](https://badgen.net/packagist/v/wordplate/framework)](https://packagist.org/packages/wordplate/framework)
-
-- [What is WordPlate?](#what-is-wordplate)
-- [Installation](#installation)
-- [Configuration](#configuration)
-- [Upgrade Guide](#upgrade-guide)
-- [FAQ](#faq)
-- [Support](#support)
-- [Contributing](#contributing)
-
-## What is WordPlate?
+![WordPlate](https://cloud.githubusercontent.com/assets/499192/24309675/09eec350-10cd-11e7-98f3-094003bc8e15.png)
 
 WordPlate is simply a wrapper around WordPress to make developers life easier. It is just like building any other WordPress website with [themes](https://developer.wordpress.org/themes) and [plugins](https://developer.wordpress.org/plugins). Just with sprinkles on top.
 
@@ -55,6 +35,17 @@ WordPlate is simply a wrapper around WordPress to make developers life easier. I
 - **Security**
     
     With the [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt#readme) package we've replaced WordPress outdated and insecure MD5-based password hashing with the modern and secure bcrypt.
+
+[![Build Status](https://badgen.net/github/checks/wordplate/framework?label=build&icon=github)](https://github.com/wordplate/framework/actions)
+[![Monthly Downloads](https://badgen.net/packagist/dm/wordplate/framework)](https://packagist.org/packages/wordplate/framework/stats)
+[![Latest Version](https://badgen.net/packagist/v/wordplate/framework)](https://packagist.org/packages/wordplate/framework)
+
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Upgrade Guide](#upgrade-guide)
+- [FAQ](#faq)
+- [Support](#support)
+- [Contributing](#contributing)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ composer create-project wordplate/wordplate
 [![Monthly Downloads](https://badgen.net/packagist/dm/wordplate/framework)](https://packagist.org/packages/wordplate/framework/stats)
 [![Latest Version](https://badgen.net/packagist/v/wordplate/framework)](https://packagist.org/packages/wordplate/framework)
 
-- [What is WordPlate?](#what-is-word-plate)
+- [What is WordPlate?](#what-is-wordplate)
 - [Installation](#installation)
 - [Configuration](#configuration)
   - [Public Directory](#public-directory)

--- a/README.md
+++ b/README.md
@@ -120,8 +120,6 @@ Read more about environment variables in Laravel's documentation:
 
 To get started with Laravel Mix, [please visit the documentation](https://laravel-mix.com/docs/5.0/basic-example).
 
-By default there are two npm scripts available:
-
 ```sh
 // Run all mix tasks...
 npm run dev

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ $ composer create-project wordplate/wordplate
 
 - [Installation](#installation)
 - [Configuration](#configuration)
+  - [Public Directory](#public-directory)
+  - [Salt Keys](#salt-keys)
 - [Upgrade Guide](#upgrade-guide)
+- [FAQ](#faq)
 
 ## Installation
 
@@ -22,11 +25,28 @@ To use WordPlate, you need to have PHP 7.2+ and MySQL 5.7+ installed on your mac
 
 WordPlate utilizes [Composer](https://getcomposer.org/) to manage its dependencies. So, before using WordPlate, make sure you have Composer installed on your machine.
 
-Install WordPlate by issuing the Composer `create-project` command in your terminal:
+1. Install WordPlate by issuing the Composer `create-project` command in your terminal:
 
-```sh
-$ composer create-project --prefer-dist laravel/laravel blog
-```
+    ```sh
+    $ composer create-project --prefer-dist wordplate/wordplate blog
+    ```
+
+1. Add your database credentials to the `.env` file.
+
+    - `DB_NAME`
+    - `DB_USER`
+    - `DB_PASSWORD`
+
+1. Serve your application using the [built-in web server in PHP](https://www.php.net/manual/en/features.commandline.webserver.php) (or your server of choice) from the `public` directory:
+
+    ```sh
+    $ php -S localhost:8000 -t public/
+    ```
+
+1. Visit your application in the browser:
+
+    - [`http://localhost:8000/`](http://localhost:8000/) - The WordPress application.
+    - [`http://localhost:8000/wordpress/wp-admin`](http://localhost:8000/wordpress/wp-admin) - The WordPress administration dashboard.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ $ composer create-project wordplate/wordplate
 [![Monthly Downloads](https://badgen.net/packagist/dm/wordplate/framework)](https://packagist.org/packages/wordplate/framework/stats)
 [![Latest Version](https://badgen.net/packagist/v/wordplate/framework)](https://packagist.org/packages/wordplate/framework)
 
-- [Installation](#installation)
+- [Introduction](#introduction)
+- [Getting Started](#getting-started)
 - [Configuration](#configuration)
   - [Public Directory](#public-directory)
   - [Salt Keys](#salt-keys)
@@ -21,7 +22,40 @@ $ composer create-project wordplate/wordplate
 - [Support](#support)
 - [Contributing](#contributing)
 
-## Installation
+## Introduction
+
+WordPlate is simply a wrapper around WordPress to make developers life easier. It is just like building any WordPress website with [themes](https://developer.wordpress.org/themes) and [plugins](https://developer.wordpress.org/plugins).
+
+### WordPress as a dependency
+
+WordPress is installed using Composer as a dependency. This allows WordPress to be updated by running `composer update` in the root of the project.
+
+### Environment Files
+
+Similar to Laravel and Symfony, WordPlate puts environment variables within an `.env` file such as database credentials and WordPress salts.
+
+### WordPress Packagist
+
+Manage your WordPress plugins and themes with Composer. WordPlate has integrated WordPress Packagist out of the box.
+
+### Must-use plugins
+
+WordPlate comes with a [must-use plugin](https://wordpress.org/support/article/must-use-plugins/) loader out of the box. This means you can lock your plugins to specific versions and they are auto-activated by default.
+
+### Mail
+
+Are you using custom SMTP credentials to send emails? WordPlate provides a package to add your credentials to the environment file.
+
+### Laravel Mix
+
+Integrated Webpack build tool which comes with several common CSS and JavaScript pre-processors. Versioning and cache busting built right in.
+
+### Security
+
+WordPlate installs the [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt#readme) package out of the box.
+
+
+## Getting Started
 
 To use WordPlate, you need to have PHP 7.2+ and MySQL 5.7+ installed on your machine. 
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,6 @@ npm run build
 
 ## Integrations
 
-### WordPlate Projects
-
 - [**Administration UI**](https://vinkla.dev/administration-ui)
 
   The plugin lets you take control over the WordPress administration dashboard by turning off features you don't use. 
@@ -186,19 +184,13 @@ npm run build
 
   The plugin integrates [Blade](https://laravel.com/docs/7.x/blade) templating system in WordPress.
 
-- [**Extended ACF**](https://github.com/wordplate/extended-acf)
-
-  The package provides an object oriented API to register fields, groups and layouts with Advanced Custom Fields.
-
-- [**Mail**](https://github.com/wordplate/mail)
-
-  The plugin provides a simple way to add custom SMTP credentials and an easier way to working with attachments.
-
-### Community Projects
-
 - [**Clean Image Filenames**](https://wordpress.org/plugins/clean-image-filenames/)
 
   The plugin removes special characters from filenames.
+
+- [**Extended ACF**](https://github.com/wordplate/extended-acf)
+
+  The package provides an object oriented API to register fields, groups and layouts with Advanced Custom Fields.
 
 - [**Extended CPTs**](https://github.com/johnbillion/extended-cpts)
 
@@ -219,6 +211,10 @@ npm run build
 - [**Hide Updates**](https://wordpress.org/plugins/hide-updates/)
 
   The plugin hides update notices for updates in WordPress.
+
+- [**Mail**](https://github.com/wordplate/mail)
+
+  The plugin provides a simple way to add custom SMTP credentials and an easier way to working with attachments.
 
 - [**WP Languages**](https://github.com/wp-languages/wp-languages.github.io)
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,34 @@ $ composer create-project wordplate/wordplate
 [![Latest Version](https://badgen.net/packagist/v/wordplate/framework)](https://packagist.org/packages/wordplate/framework)
 
 - [Installation](#installation)
+- [Configuration](#configuration)
 - [Upgrade Guide](#upgrade-guide)
 
 ## Installation
 
-Visit the [official documentation](https://wordplate.github.io/) page if you want to dive right in and start building WordPress applications with WordPlate. The documentation is thorough, complete, and makes it a breeze to get started learning WordPlate.
+To use WordPlate, you need to have PHP 7.2+ and MySQL 5.7+ installed on your machine. 
+
+WordPlate utilizes [Composer](https://getcomposer.org/) to manage its dependencies. So, before using WordPlate, make sure you have Composer installed on your machine.
+
+Install WordPlate by issuing the Composer `create-project` command in your terminal:
+
+```sh
+$ composer create-project --prefer-dist laravel/laravel blog
+```
+
+## Configuration
+
+### Public Directory
+
+After installing WordPlate, you should configure your web server's document / web root to be the `public` directory. The `index.php` in this directory serves as the front controller for all HTTP requests entering your application.
+
+### Salt Keys
+
+The next thing you should do after installing WordPlate is adding salt keys to your environment file.
+
+Typically, these strings should be 64 characters long. The keys can be set in the `.env` environment file. If you have not copied the `.env.example` file to a new file named `.env`, you should do that now. **If the salt keys isn't set, your user sessions and other encrypted data will not be secure.**
+
+If you're lazy like us, [visit our salt key generator](https://wordplate.github.io/salt) and copy the randomly generated keys to your `.env` file.
 
 ## Upgrade Guide
 
@@ -94,6 +117,20 @@ If you're running an older version of WordPlate and want to upgrade, please see 
    > **Note:** Make sure you don't overwrite any of your custom constants.
 
 1. Run `composer update` in the root of your project and your app should be up and running!
+</details>
+
+## FAQ
+
+<details>
+<summary><strong>Can I change the name of the public directory?</strong></summary>
+
+If you want to rename the `public` directory you'll need to add the following line to the `wp-config.php` file:
+
+```php
+$application->setPublicPath(realpath(__DIR__));
+```
+
+Please note that you also have to update your `composer.json` file with your new `public` directory path before you can run `composer update` again.
 </details>
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ Typically, these strings should be 64 characters long. The keys can be set in th
 
 If you're lazy like us, [visit our salt key generator](https://wordplate.github.io/salt) and copy the randomly generated keys to your `.env` file.
 
+### Environment Configuration
+
+It is often helpful to have different configuration values based on the environment where the application is running. For example, you may wish to use a different database locally than you do on your production server.
+
+To make this a cinch, WordPlate utilizes the [Dotenv](https://symfony.com/doc/current/components/dotenv) PHP library by Symfony. In a fresh WordPlate installation, the root directory of your application will contain a `.env.example` file. If you install WordPlate via Composer, this file will automatically be renamed to `.env`. Otherwise, you should rename the file manually.
+
+Your `.env` file should not be committed to your application's source control, since each developer / server using your application could require a different environment configuration. Furthermore, this would be a security risk in the event an intruder gains access to your source control repository, since any sensitive credentials would get exposed.
+
+Read more about environment variables in Laravel's documentation:
+
+- [Environment Variable Types](https://laravel.com/docs/7.x/configuration#environment-variable-types)
+- [Retrieving Environment Configuration](https://laravel.com/docs/7.x/configuration#retrieving-environment-configuration)
+
 ## Laravel Mix
 
 [Laravel Mix](https://laravel-mix.com/docs/5.0/basic-example) is a clean layer on top of Webpack to make the 80% use case laughably simple to execute. Most would agree that, though incredibly powerful, Webpack ships with a steep learning curve. But what if you didn't have to worry about that?

--- a/README.md
+++ b/README.md
@@ -62,30 +62,30 @@ To use WordPlate, you need to have PHP 7.2+ and MySQL 5.7+ installed on your mac
 
 WordPlate utilizes [Composer](https://getcomposer.org/) to manage its dependencies. So, before using WordPlate, make sure you have Composer installed on your machine.
 
-1. Install WordPlate by issuing the Composer `create-project` command in your terminal:
+Install WordPlate by issuing the Composer `create-project` command in your terminal:
 
-    ```sh
-    $ composer create-project --prefer-dist wordplate/wordplate blog
-    ```
+```sh
+$ composer create-project --prefer-dist wordplate/wordplate blog
+```
 
-1. Update the database credentials in the `.env` file:
+Update the database credentials in the `.env` file:
 
-    ```
-    DB_NAME=database
-    DB_USER=username
-    DB_PASSWORD=password
-    ```
+```
+DB_NAME=database
+DB_USER=username
+DB_PASSWORD=password
+```
 
-1. Serve your application using the [built-in web server in PHP](https://www.php.net/manual/en/features.commandline.webserver.php) (or your server of choice) from the `public` directory:
+Serve your application using the [built-in web server in PHP](https://www.php.net/manual/en/features.commandline.webserver.php) (or your server of choice) from the `public` directory:
 
-    ```sh
-    $ php -S localhost:8000 -t public/
-    ```
+```sh
+$ php -S localhost:8000 -t public/
+```
 
-1. Visit your application in the browser:
+Visit your application in the browser:
 
-    - [`http://localhost:8000/`](http://localhost:8000/) - Your website.
-    - [`http://localhost:8000/wordpress/wp-admin`](http://localhost:8000/wordpress/wp-admin) - The administration dashboard.
+- [`http://localhost:8000/`](http://localhost:8000/) - Your website.
+- [`http://localhost:8000/wordpress/wp-admin`](http://localhost:8000/wordpress/wp-admin) - The administration dashboard.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -26,37 +26,37 @@ $ composer create-project wordplate/wordplate
 
 WordPlate is simply a wrapper around WordPress to make developers life easier. It is just like building any other WordPress website with [themes](https://developer.wordpress.org/themes) and [plugins](https://developer.wordpress.org/plugins). Just with sprinkles on top.
 
-#### WordPress + Composer = ♥️
+- **WordPress + Composer = ♥️**
+    
+    WordPress is installed using Composer which allows WordPress to be updated by running `composer update`.
 
-WordPress is installed using Composer which allows WordPress to be updated by running `composer update`.
+- **Environment Files**
+    
+    Similar to Laravel, WordPlate puts environment variables within an `.env` file such as database credentials.
 
-#### Environment Files
+- **WordPress Packagist**
+    
+    With WordPress Packagist you may manage your WordPress plugins and themes with Composer.
 
-Similar to Laravel, WordPlate puts environment variables within an `.env` file such as database credentials.
+- **Must-use plugins**
+    
+    Don't worry about client deactivating plugins, [must-use plugins](https://wordpress.org/support/article/must-use-plugins/) is enabled by default.
 
-#### WordPress Packagist
+- **Mail**
+    
+    If you want to use custom SMTP credentials to send emails, we've a package for that!
 
-With WordPress Packagist you may manage your WordPress plugins and themes with Composer.
+- **Laravel Mix**
+    
+    With Laravel Mix you can quickly get up and running with Webpack to build and minify your CSS and JavaScript.
 
-#### Must-use plugins
+- **Debugging**
+    
+    Familiar debugging helper functions are integrated such as `dump()` and `dd()`.
 
-Don't worry about client deactivating plugins, [must-use plugins](https://wordpress.org/support/article/must-use-plugins/) is enabled by default.
-
-#### Mail
-
-If you want to use custom SMTP credentials to send emails, we've a package for that!
-
-#### Laravel Mix
-
-With Laravel Mix you can quickly get up and running with Webpack to build and minify your CSS and JavaScript.
-
-#### Debugging
-
-Familiar debugging helper functions are integrated such as `dump()` and `dd()`.
-
-#### Security
-
-With the [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt#readme) package we've replaced WordPress outdated and insecure MD5-based password hashing with the modern and secure bcrypt.
+- **Security**
+    
+    With the [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt#readme) package we've replaced WordPress outdated and insecure MD5-based password hashing with the modern and secure bcrypt.
 
 ## Installation
 
@@ -294,7 +294,7 @@ final class LocalValetDriver extends BasicValetDriver
 
 ## Support ♥️
 
-If you or a company you work for use WordPlate, please consider buying a copy of the [Administration UI](https://vinkla.dev/administration-ui) plugin. This will not only make your clients happy, it will also help use maintain and push WordPlate forward.
+If you or a company you work for use WordPlate, please consider buying a copy of the [Administration UI](https://vinkla.dev/administration-ui) plugin. This will not only make your clients happy, it will also help us maintain and push WordPlate forward.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If you're lazy like us, [visit our salt key generator](https://wordplate.github.
 
 It is often helpful to have different configuration values based on the environment where the application is running. For example, you may wish to use a different database locally than you do on your production server.
 
-To make this a cinch, WordPlate utilizes the [Dotenv](https://symfony.com/doc/current/components/dotenv) PHP library by Symfony. In a fresh WordPlate installation, the root directory of your application will contain a `.env.example` file. If you install WordPlate via Composer, this file will automatically be renamed to `.env`. Otherwise, you should rename the file manually.
+To make this a cinch, WordPlate utilizes the [Dotenv](https://symfony.com/doc/current/components/dotenv) PHP package by Symfony. In a fresh WordPlate installation, the root directory of your application will contain a `.env.example` file. If you install WordPlate via Composer, this file will automatically be renamed to `.env`. Otherwise, you should rename the file manually.
 
 Your `.env` file should not be committed to your application's source control, since each developer / server using your application could require a different environment configuration. Furthermore, this would be a security risk in the event an intruder gains access to your source control repository, since any sensitive credentials would get exposed.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you're running an older version of WordPlate and want to upgrade, please see 
    $application->setPublicPath(realpath(__DIR__));
    ```
 
-1. Run `composer update` and everything should work as before.
+1. Run `composer update` in the root of your project and your app should be up and running!
 </details>
 <details>
 <summary><strong>Upgrading from 5 to 6</strong></summary>
@@ -82,7 +82,7 @@ If you're running an older version of WordPlate and want to upgrade, please see 
 
 1. Update the `realpath(__DIR__.'/../')` to `realpath(__DIR__)` in the `wp-config.php` file.
 
-1. Run `composer update` and everything should work as before.
+1. Run `composer update` in the root of your project and your app should be up and running!
 </details>
 <details>
 <summary><strong>Upgrading from 4 to 5</strong></summary>
@@ -93,7 +93,7 @@ If you're running an older version of WordPlate and want to upgrade, please see 
 
    > **Note:** Make sure you don't overwrite any of your custom constants.
 
-1. Run `composer update`.
+1. Run `composer update` in the root of your project and your app should be up and running!
 </details>
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ $ composer create-project wordplate/wordplate
 [![Monthly Downloads](https://badgen.net/packagist/dm/wordplate/framework)](https://packagist.org/packages/wordplate/framework/stats)
 [![Latest Version](https://badgen.net/packagist/v/wordplate/framework)](https://packagist.org/packages/wordplate/framework)
 
-- [Introduction](#introduction)
-- [Getting Started](#getting-started)
+- [What is WordPlate?](#what-is-word-plate)
+- [Installation](#installation)
 - [Configuration](#configuration)
   - [Public Directory](#public-directory)
   - [Salt Keys](#salt-keys)
@@ -22,40 +22,39 @@ $ composer create-project wordplate/wordplate
 - [Support](#support)
 - [Contributing](#contributing)
 
-## Introduction
+## What is WordPlate?
 
-WordPlate is simply a wrapper around WordPress to make developers life easier. It is just like building any WordPress website with [themes](https://developer.wordpress.org/themes) and [plugins](https://developer.wordpress.org/plugins).
+WordPlate is simply a wrapper around WordPress to make developers life easier. It is just like building any other WordPress website with [themes](https://developer.wordpress.org/themes) and [plugins](https://developer.wordpress.org/plugins). Just with sprinkles on top.
 
-#### WordPress as a dependency
+#### WordPress + Composer = ♥️
 
-WordPress is installed using Composer as a dependency. This allows WordPress to be updated by running `composer update` in the root of the project.
+WordPress is installed using Composer which allows WordPress to be updated by running `composer update`.
 
 #### Environment Files
 
-Similar to Laravel and Symfony, WordPlate puts environment variables within an `.env` file such as database credentials and WordPress salts.
+Similar to Laravel, WordPlate puts environment variables within an `.env` file such as database credentials.
 
 #### WordPress Packagist
 
-Manage your WordPress plugins and themes with Composer. WordPlate has integrated WordPress Packagist out of the box.
+With WordPress Packagist you may manage your WordPress plugins and themes with Composer.
 
 #### Must-use plugins
 
-WordPlate comes with a [must-use plugin](https://wordpress.org/support/article/must-use-plugins/) loader out of the box. This means you can lock your plugins to specific versions and they are auto-activated by default.
+Don't worry about client deactivating plugins, [must-use plugins](https://wordpress.org/support/article/must-use-plugins/) is enabled by default.
 
 #### Mail
 
-Are you using custom SMTP credentials to send emails? WordPlate provides a package to add your credentials to the environment file.
+If you want to use custom SMTP credentials to send emails, we've a package for that!
 
 #### Laravel Mix
 
-Integrated Webpack build tool which comes with several common CSS and JavaScript pre-processors. Versioning and cache busting built right in.
+With Laravel Mix you can quickly get up and running with Webpack to build and minify your CSS and JavaScript.
 
 #### Security
 
-WordPlate installs the [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt#readme) package out of the box.
+With the [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt#readme) package we've replaced WordPress outdated and insecure MD5-based password hashing with the modern and secure bcrypt.
 
-
-## Getting Started
+## Installation
 
 To use WordPlate, you need to have PHP 7.2+ and MySQL 5.7+ installed on your machine. 
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ npm run build
 
 ## Integrations
 
+### WordPlate Projects
+
 - [**Administration UI**](https://vinkla.dev/administration-ui)
 
   The plugin lets you take control over the WordPress administration dashboard by turning off features you don't use. 
@@ -184,13 +186,19 @@ npm run build
 
   The plugin integrates [Blade](https://laravel.com/docs/7.x/blade) templating system in WordPress.
 
-- [**Clean Image Filenames**](https://wordpress.org/plugins/clean-image-filenames/)
-
-  The plugin removes special characters from filenames.
-
 - [**Extended ACF**](https://github.com/wordplate/extended-acf)
 
   The package provides an object oriented API to register fields, groups and layouts with Advanced Custom Fields.
+
+- [**Mail**](https://github.com/wordplate/mail)
+
+  The plugin provides a simple way to add custom SMTP credentials and an easier way to working with attachments.
+
+### Community Projects
+
+- [**Clean Image Filenames**](https://wordpress.org/plugins/clean-image-filenames/)
+
+  The plugin removes special characters from filenames.
 
 - [**Extended CPTs**](https://github.com/johnbillion/extended-cpts)
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ WordPlate is simply a wrapper around WordPress to make developers life easier. I
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Plugins](#plugins)
-- [Integrations](#integrations)
 - [Laravel Mix](#laravel-mix)
+- [Integrations](#integrations)
 - [Upgrade Guide](#upgrade-guide)
 - [FAQ](#faq)
 - [Support](#support)
@@ -160,6 +160,20 @@ The plugin should now be installed in the `public/mu-plugins` directory.
 
 [Read more about the must-use plugin autoloader in the documentation.](https://roots.io/docs/bedrock/master/mu-plugin-autoloader/)
 
+## Laravel Mix
+
+[Laravel Mix](https://laravel-mix.com/docs/5.0/basic-example) is a clean layer on top of Webpack to make the 80% use case laughably simple to execute. Most would agree that, though incredibly powerful, Webpack ships with a steep learning curve. But what if you didn't have to worry about that?
+
+[To get started with Laravel Mix, please visit the documentation.](https://laravel-mix.com/docs/5.0/basic-example)
+
+```sh
+// Run all mix tasks...
+npm run dev
+
+// Run all mix tasks and minify output...
+npm run build
+```
+
 ## Integrations
 
 - [**Administration UI**](https://vinkla.dev/administration-ui)
@@ -205,20 +219,6 @@ The plugin should now be installed in the `public/mu-plugins` directory.
 - [**WP Migrate DB**](https://wordpress.org/plugins/wp-migrate-db/)
 
   The plugin help you export your database as a MySQL data dump.
-
-## Laravel Mix
-
-[Laravel Mix](https://laravel-mix.com/docs/5.0/basic-example) is a clean layer on top of Webpack to make the 80% use case laughably simple to execute. Most would agree that, though incredibly powerful, Webpack ships with a steep learning curve. But what if you didn't have to worry about that?
-
-[To get started with Laravel Mix, please visit the documentation.](https://laravel-mix.com/docs/5.0/basic-example)
-
-```sh
-// Run all mix tasks...
-npm run dev
-
-// Run all mix tasks and minify output...
-npm run build
-```
 
 ## Upgrade Guide
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ If you want to use custom SMTP credentials to send emails, we've a package for t
 
 With Laravel Mix you can quickly get up and running with Webpack to build and minify your CSS and JavaScript.
 
+#### Debugging
+
+Familiar debugging helper functions are integrated such as `dump()` and `dd()`.
+
 #### Security
 
 With the [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt#readme) package we've replaced WordPress outdated and insecure MD5-based password hashing with the modern and secure bcrypt.
@@ -115,8 +119,6 @@ npm run build
 ```
 
 ## Upgrade Guide
-
-If you're running an older version of WordPlate and want to upgrade, please see the guides below.
 
 <details>
 <summary><strong>Upgrading from 7 to 8</strong></summary>
@@ -194,7 +196,7 @@ If you're running an older version of WordPlate and want to upgrade, please see 
 ## FAQ
 
 <details>
-<summary><strong>Can I change the name of the public directory?</strong></summary>
+<summary><strong>Can I rename the public directory?</strong></summary>
 
 If you want to rename the `public` directory you'll need to add the following line to the `wp-config.php` file:
 
@@ -203,6 +205,30 @@ $application->setPublicPath(realpath(__DIR__));
 ```
 
 Please note that you also have to update your `composer.json` file with your new `public` directory path before you can run `composer update` again.
+</details>
+<details>
+<summary><strong>Can I rename the WordPress directory?</strong></summary>
+
+By default WordPlate will put the WordPress in `public/wordpress`. If you want to change this there are a couple of steps you need to go through. Let's say you want to change the default WordPress location to `public/wp`:
+
+1. Update the `wordpress-install-dir` path in your `composer.json` file.
+
+2. Update `wordpress` to `wp` in `wordplate/public/.gitignore`.
+
+3. Update the last line in the `public/index.php` file to:
+    
+    ```php
+    require __DIR__.'/wp/wp-blog-header.php';
+    ```
+
+4. If you're using WP-CLI, update the path in the `wp-cli.yml` file to `public/wp`.
+
+5. Remove the `public/wordpress` directory if it exist and then run `composer update`.
+</details>
+<details>
+<summary><strong>Can I rename the theme directory?</strong></summary>
+
+For most applications you may leave the theme directory as it is. If you want to rename the `wordplate` theme to something else you'll also need to update the `WP_THEME` environment variable in the `.env` file.
 </details>
 <details>
 <summary><strong>Can I use WordPlate with Laravel Valet?</strong></summary>

--- a/README.md
+++ b/README.md
@@ -12,9 +12,89 @@ $ composer create-project wordplate/wordplate
 [![Monthly Downloads](https://badgen.net/packagist/dm/wordplate/framework)](https://packagist.org/packages/wordplate/framework/stats)
 [![Latest Version](https://badgen.net/packagist/v/wordplate/framework)](https://packagist.org/packages/wordplate/framework)
 
-## Documentation
+- [Installation](#installation)
+- [Upgrade Guide](#upgrade-guide)
+
+## Installation
 
 Visit the [official documentation](https://wordplate.github.io/) page if you want to dive right in and start building WordPress applications with WordPlate. The documentation is thorough, complete, and makes it a breeze to get started learning WordPlate.
+
+## Upgrade Guide
+
+If you're running an older version of WordPlate and want to upgrade, please see the guides below.
+
+<details>
+<summary><strong>Upgrading from 7 to 8</strong></summary>
+
+1. WordPlate now requires PHP 7.2 or later.
+
+1. Bump the version number in the `composer.json` file to `^8.0`.
+
+   > **Note:** WordPlate 8.0 requires WordPress 5.3 or later.
+
+1. Laravel's helper functions is now optional in WordPlate. If you want to use the functions, install the [`laravel/helpers`](https://github.com/laravel/helpers#readme) package, with Composer, in the root of your project:
+
+   ```sh
+   $ composer require laravel/helpers
+   ```
+
+1. Laravel's collections are now optional in WordPlate. If you want to use collections, install the [`tightenco/collect`](https://github.com/tightenco/collect#readme) package, with Composer, in the root of your project:
+
+   ```sh
+   $ composer require tightenco/collect
+   ```
+
+1. The `mix` helper function is now optional in WordPlate. If you want to use the function, install the [`ibox/mix-function`](https://github.com/juanem1/mix-function#readme) package, with Composer, in the root of your project:
+
+   ```sh
+   $ composer require ibox/mix-function
+   ```
+
+1. Replace any usage of `asset`, `stylesheet_url` and `template_url` functions with WordPress's [`get_theme_file_uri`](https://developer.wordpress.org/reference/functions/get_theme_file_uri/) function.
+
+1. Replace any usage of `stylesheet_path` and `template_path` functions with WordPress's [`get_theme_file_path`](https://developer.wordpress.org/reference/functions/get_theme_file_path/) function .
+
+1. The `base_path` and `template_slug` functions have been removed.
+
+1. Run `composer update` in the root of your project and your app should be up and running!
+</details>
+<details>
+<summary><strong>Upgrading from 6 to 7</strong></summary>
+
+1. Bump the version number in the `composer.json` file to `^7.0`.
+
+   > **Note:** WordPlate 7.0 requires WordPress 5.0 or later.
+
+1. Update the `realpath(__DIR__)` to `realpath(__DIR__.'/../')` in the `wp-config.php` file.
+
+1. If your public directory isn't named `public`, add the following line to the `wp-config.php` file:
+
+   ```php
+   $application->setPublicPath(realpath(__DIR__));
+   ```
+
+1. Run `composer update` and everything should work as before.
+</details>
+<details>
+<summary><strong>Upgrading from 5 to 6</strong></summary>
+
+1. Bump the version number in the `composer.json` file to `^6.0`.
+
+1. Update the `realpath(__DIR__.'/../')` to `realpath(__DIR__)` in the `wp-config.php` file.
+
+1. Run `composer update` and everything should work as before.
+</details>
+<details>
+<summary><strong>Upgrading from 4 to 5</strong></summary>
+
+1. Bump the version number in the `composer.json` file to `^5.0`.
+
+1. Copy and paste the contents of the [`wp-config.php`](public/wp-config.php) file into your application.
+
+   > **Note:** Make sure you don't overwrite any of your custom constants.
+
+1. Run `composer update`.
+</details>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you're running an older version of WordPlate and want to upgrade, please see 
 
 <details>
 <summary><strong>Can I change the name of the public directory?</strong></summary>
-
+<br>
 If you want to rename the `public` directory you'll need to add the following line to the `wp-config.php` file:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ $ composer create-project wordplate/wordplate
 - [What is WordPlate?](#what-is-wordplate)
 - [Installation](#installation)
 - [Configuration](#configuration)
-  - [Public Directory](#public-directory)
-  - [Salt Keys](#salt-keys)
 - [Upgrade Guide](#upgrade-guide)
 - [FAQ](#faq)
 - [Support](#support)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 WordPlate is simply a wrapper around WordPress to make developers life easier. It is just like building any other WordPress website with [themes](https://developer.wordpress.org/themes) and [plugins](https://developer.wordpress.org/plugins). Just with sprinkles on top.
 
+[![Build Status](https://badgen.net/github/checks/wordplate/framework?label=build&icon=github)](https://github.com/wordplate/framework/actions)
+[![Monthly Downloads](https://badgen.net/packagist/dm/wordplate/framework)](https://packagist.org/packages/wordplate/framework/stats)
+[![Latest Version](https://badgen.net/packagist/v/wordplate/framework)](https://packagist.org/packages/wordplate/framework)
+
+- [Features](#features)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Upgrade Guide](#upgrade-guide)
+- [FAQ](#faq)
+- [Support](#support)
+- [Contributing](#contributing)
+
+## Features
+
 - **WordPress + Composer = ♥️**
     
     WordPress is installed using Composer which allows WordPress to be updated by running `composer update`.
@@ -35,17 +49,6 @@ WordPlate is simply a wrapper around WordPress to make developers life easier. I
 - **Security**
     
     With the [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt#readme) package we've replaced WordPress outdated and insecure MD5-based password hashing with the modern and secure bcrypt.
-
-[![Build Status](https://badgen.net/github/checks/wordplate/framework?label=build&icon=github)](https://github.com/wordplate/framework/actions)
-[![Monthly Downloads](https://badgen.net/packagist/dm/wordplate/framework)](https://packagist.org/packages/wordplate/framework/stats)
-[![Latest Version](https://badgen.net/packagist/v/wordplate/framework)](https://packagist.org/packages/wordplate/framework)
-
-- [Installation](#installation)
-- [Configuration](#configuration)
-- [Upgrade Guide](#upgrade-guide)
-- [FAQ](#faq)
-- [Support](#support)
-- [Contributing](#contributing)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -26,31 +26,31 @@ $ composer create-project wordplate/wordplate
 
 WordPlate is simply a wrapper around WordPress to make developers life easier. It is just like building any WordPress website with [themes](https://developer.wordpress.org/themes) and [plugins](https://developer.wordpress.org/plugins).
 
-### WordPress as a dependency
+#### WordPress as a dependency
 
 WordPress is installed using Composer as a dependency. This allows WordPress to be updated by running `composer update` in the root of the project.
 
-### Environment Files
+#### Environment Files
 
 Similar to Laravel and Symfony, WordPlate puts environment variables within an `.env` file such as database credentials and WordPress salts.
 
-### WordPress Packagist
+#### WordPress Packagist
 
 Manage your WordPress plugins and themes with Composer. WordPlate has integrated WordPress Packagist out of the box.
 
-### Must-use plugins
+#### Must-use plugins
 
 WordPlate comes with a [must-use plugin](https://wordpress.org/support/article/must-use-plugins/) loader out of the box. This means you can lock your plugins to specific versions and they are auto-activated by default.
 
-### Mail
+#### Mail
 
 Are you using custom SMTP credentials to send emails? WordPlate provides a package to add your credentials to the environment file.
 
-### Laravel Mix
+#### Laravel Mix
 
 Integrated Webpack build tool which comes with several common CSS and JavaScript pre-processors. Versioning and cache busting built right in.
 
-### Security
+#### Security
 
 WordPlate installs the [`roots/wp-password-bcrypt`](https://github.com/roots/wp-password-bcrypt#readme) package out of the box.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wordplate/wordplate",
-    "description": "A modern WordPress stack built with Composer",
+    "description": "A modern WordPress stack to make PHP developers happier",
     "keywords": [
         "wordplate",
         "wordpress",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "start": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "dependencies": {
     "cross-env": "^7.0.0",

--- a/public/index.php
+++ b/public/index.php
@@ -34,4 +34,4 @@ define('WP_USE_THEMES', true);
 |
 */
 
-require __DIR__.'/wordpress/wp-blog-header.php';
+require __DIR__ . '/wordpress/wp-blog-header.php';

--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 add_action('after_setup_theme', function () {
     add_theme_support('post-thumbnails');
 

--- a/public/themes/wordplate/index.php
+++ b/public/themes/wordplate/index.php
@@ -1,15 +1,16 @@
 <?php get_header(); ?>
 
 <main role="main">
-    <?php if (have_posts()): while (have_posts()): the_post(); ?>
-        <article>
-            <header>
-                <h1><?php the_title(); ?></h1>
-            </header>
+    <?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+            <article>
+                <header>
+                    <h1><?php the_title(); ?></h1>
+                </header>
 
-            <?php the_content(); ?>
-        </article>
-    <?php endwhile; else: ?>
+                <?php the_content(); ?>
+            </article>
+        <?php endwhile;
+    else : ?>
         <article>
             <p>Nothing to see.</p>
         </article>

--- a/public/themes/wordplate/style.css
+++ b/public/themes/wordplate/style.css
@@ -1,8 +1,8 @@
 /**
  * Theme Name: WordPlate
- * Theme URI: https://wordplate.github.io/
- * Description: WordPress theme built with <a href="https://wordplate.github.io/">WordPlate</a>.
+ * Theme URI: https://github.com/wordplate/wordplate
+ * Description: WordPress theme built with <a href="https://github.com/wordplate/wordplate">WordPlate</a>.
  * Version: 1.0.0
  * Author: WordPlate
- * Author URI: https://wordplate.github.io/
+ * Author URI: https://github.com/wordplate/wordplate
  */

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 |
 */
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 /*
 |--------------------------------------------------------------------------
@@ -37,7 +37,7 @@ require __DIR__.'/../vendor/autoload.php';
 */
 
 $application = new WordPlate\Application(
-    realpath(__DIR__.'/../')
+    realpath(__DIR__ . '/../')
 );
 
 /*
@@ -89,4 +89,4 @@ $application->run();
 |
 */
 
-require_once ABSPATH.'wp-settings.php';
+require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
This pull request adds the documentation to the `README.md` file. I realize we've come full circle here. The documentation was previously part of the repository.

Benefits:

- We'll rewrite the documentation and simplify it as much as possible.
- Instead of writing documentation about other projects we'll link to their documentation instead.
- The documentation will be shipped with every new WordPlate project.

[View the rendered Markdown.](https://github.com/wordplate/wordplate/blob/7500cb39b5b00d94ebf8d24ce951afd736c6ed76/README.md)