### PR TITLE
Add instructions for .gitignore'ing the mu-plugins.php file

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ Below you'll find a list of plugins and packages we use with WordPlate. Some of 
 
 1. Copy the `public/mu-plugins/mu-plugins.php` file into your project.
 
+1. Add `!mu-plugins/mu-plugins.php` to your project's `public/.gitignore` file.
+
 1. Run `composer update` in the root of your project and your app should be up and running!
 </details>
 <details>


### PR DESCRIPTION
Hi there!

When upgrading from version 8 to version 9, the new `mu-plugins.php` should be added to the `public/.gitignore` file.

I almost missed this step, so I thought maybe this should be clarified in the upgrade instructions.

Thank you very much for WordPlate! 🎉 