### PR TITLE
Rename database table prefix variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 WP_ENV=local
 WP_DEBUG=true
 WP_DEFAULT_THEME=wordplate
-WP_PREFIX=wp_
 
 DB_HOST=127.0.0.1
 DB_NAME=wordplate
 DB_USER=root
 DB_PASSWORD=
+DB_TABLE_PREFIX=wp_
 
 # https://wordplate.github.io/salt/
 AUTH_KEY=

--- a/README.md
+++ b/README.md
@@ -309,13 +309,13 @@ $application->run();
 
 +define('WP_ALLOW_MULTISITE', env('WP_ALLOW_MULTISITE', true));
 
-$table_prefix = env('WP_PREFIX', 'wp_');
+$table_prefix = env('DB_TABLE_PREFIX', 'wp_');
 ````
 
 Then you may add the constant to the `.env` file.
 
 ```diff
-WP_PREFIX=wp_
+WP_DEFAULT_THEME=wordplate
 +WP_ALLOW_MULTISITE=true
 ````
 

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -5,6 +5,6 @@ require __DIR__ . '/../vendor/autoload.php';
 $application = new WordPlate\Application(realpath(__DIR__ . '/../'));
 $application->run();
 
-$table_prefix = env('WP_PREFIX', 'wp_');
+$table_prefix = env('DB_TABLE_PREFIX', 'wp_');
 
 require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
This pull request rename the `WP_PREFIX` to `DB_TABLE_PREFIX`. The new name makes more sense since it is related to the database. This will be shipped in the next major version av WordPlate.