### PR TITLE
Remove comments in `index.php` and `wp-config.php`

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,9 @@ Below you'll find a list of plugins and packages we use with WordPlate. Some of 
 ## FAQ
 
 <details>
-<summary><strong>Can I add custom WordPress constants to the environment file?</strong></summary>
+<summary><strong>Can I add WordPress constants to the environment file?</strong></summary>
 
-This is possible by updating the `wp-config.php` file after the WordPlate application have been created.
+This is possible by updating the `public/wp-config.php` file after the WordPlate application have been created.
 
 ```diff
 $application->run();
@@ -311,6 +311,14 @@ $application->run();
 
 require_once ABSPATH . 'wp-settings.php';
 ````
+
+Then you may add the constant to the `.env` file.
+
+```diff
+WP_PREFIX=wp_
++WP_ALLOW_MULTISITE=true
+````
+
 </details>
 <details>
 <summary><strong>Can I rename the public directory?</strong></summary>

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you're lazy like us, [visit our salt key generator](https://wordplate.github.
 
 It is often helpful to have different configuration values based on the environment where the application is running. For example, you may wish to use a different database locally than you do on your production server.
 
-To make this a cinch, WordPlate utilizes the [Dotenv](https://symfony.com/doc/current/components/dotenv) PHP package by Symfony. In a fresh WordPlate installation, the root directory of your application will contain a `.env.example` file. If you install WordPlate via Composer, this file will automatically be renamed to `.env`. Otherwise, you should rename the file manually.
+To make this a cinch, WordPlate utilizes the [Dotenv](https://github.com/vlucas/phpdotenv) PHP package. In a fresh WordPlate installation, the root directory of your application will contain a `.env.example` file. If you install WordPlate via Composer, this file will automatically be renamed to `.env`. Otherwise, you should rename the file manually.
 
 Your `.env` file should not be committed to your application's source control, since each developer / server using your application could require a different environment configuration. Furthermore, this would be a security risk in the event an intruder gains access to your source control repository, since any sensitive credentials would get exposed.
 
@@ -299,6 +299,19 @@ Below you'll find a list of plugins and packages we use with WordPlate. Some of 
 
 ## FAQ
 
+<details>
+<summary><strong>Can I add custom WordPress constants to the `.env` file?</strong></summary>
+
+This is possible by updating the `wp-config.php` file after the WordPlate application have been created.
+
+```diff
+$application->run();
+
++define('WP_ALLOW_MULTISITE', env('WP_ALLOW_MULTISITE', true));
+
+require_once ABSPATH . 'wp-settings.php';
+````
+</details>
 <details>
 <summary><strong>Can I rename the public directory?</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Below you'll find a list of plugins and packages we use with WordPlate. Some of 
 ## FAQ
 
 <details>
-<summary><strong>Can I add custom WordPress constants to the `.env` file?</strong></summary>
+<summary><strong>Can I add custom WordPress constants to the environment file?</strong></summary>
 
 This is possible by updating the `wp-config.php` file after the WordPlate application have been created.
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,26 +1,5 @@
 <?php
 
-/*
-|--------------------------------------------------------------------------
-| Theming WordPress
-|--------------------------------------------------------------------------
-|
-| We need to define and tell WordPress to load the WordPress theme and
-| output it to the client's browser.
-|
-*/
-
 define('WP_USE_THEMES', true);
-
-/*
-|--------------------------------------------------------------------------
-| Booting WordPress
-|--------------------------------------------------------------------------
-|
-| This is the front to the WordPress application. This file doesn't do
-| anything, but loads wp-blog-header.php which does and tells WordPress to
-| load the theme.
-|
-*/
 
 require __DIR__ . '/wordpress/wp-blog-header.php';

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -1,81 +1,10 @@
 <?php
 
-/*
-|--------------------------------------------------------------------------
-| Register The Composer Auto Loader
-|--------------------------------------------------------------------------
-|
-| Composer provides a convenient, automatically generated class loader
-| for our application. We just need to utilize it! We'll require it
-| into the script here so that we do not have to worry about the
-| loading of any our classes "manually".
-|
-*/
-
 require __DIR__ . '/../vendor/autoload.php';
-
-/*
-|--------------------------------------------------------------------------
-| Create The Application
-|--------------------------------------------------------------------------
-|
-| The first thing we will do is create a new WordPlate application instance
-| which serves as the "glue" for all the components of WordPlate, and is
-| the container for the system binding all of the various parts.
-|
-*/
-
-$application = new WordPlate\Application(
-    realpath(__DIR__ . '/../')
-);
-
-/*
-|--------------------------------------------------------------------------
-| Custom WordPress Constants
-|--------------------------------------------------------------------------
-|
-| Below you can add custom WordPress constants which aren't specified in
-| application class. You may of course use the env() helper function.
-|
-*/
-
-// define('WP_ALLOW_MULTISITE', env('WP_ALLOW_MULTISITE', true));
-
-/*
-|--------------------------------------------------------------------------
-| WordPress Database Table Prefix
-|--------------------------------------------------------------------------
-|
-| You can have multiple installations in one database if you give each
-| a unique prefix. Only numbers, letters, and underscores please!
-|
-*/
 
 $table_prefix = env('WP_PREFIX', 'wp_');
 
-/*
-|--------------------------------------------------------------------------
-| Run The Application
-|--------------------------------------------------------------------------
-|
-| Once we have the application, we can start the engine. This bootstraps
-| the framework and gets it ready for use, then it will load up this
-| application so that we can run it and send the responses back to the
-| browser and delight our users.
-|
-*/
-
+$application = new WordPlate\Application(realpath(__DIR__ . '/../'));
 $application->run();
-
-/*
-|--------------------------------------------------------------------------
-| Bootstrap WordPress Framework
-|--------------------------------------------------------------------------
-|
-| The settings file is used to set up and fix common variables and include
-| the WordPress procedural and class library. We also need to keep this
-| include here in order to support WP-CLI.
-|
-*/
 
 require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
This pull request simplifies the `index.php` and `wp-config.php` files.