### PR TITLE
Rename WP_ENV to WP_ENVIRONMENT_TYPE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-WP_ENV=local
 WP_DEBUG=true
 WP_DEFAULT_THEME=wordplate
+WP_ENVIRONMENT_TYPE=local
 
 DB_HOST=127.0.0.1
 DB_NAME=wordplate


### PR DESCRIPTION
This pull request will update the `WP_ENV` variabel to the default `WP_ENVIRONMENT_TYPE` constant.

Depends on https://github.com/wordplate/framework/pull/107